### PR TITLE
Refresh README and architecture doc page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,14 @@
-# netman-release
+# Netman
 
-A [Garden-runC](https://github.com/cloudfoundry/garden-runc-release) add-on that provides container networking for CloudFoundry.
+Container Networking for CloudFoundry
 
-## Overview
+## Downloads
+- BOSH release [ (?) ](http://bosh.io/docs/release.html) available on
+  [bosh.io](http://bosh.io/releases/github.com/cloudfoundry-incubator/netman-release)
+  and [GitHub Releases](https://github.com/cloudfoundry-incubator/netman-release/releases)
+- CF CLI Plugin [ (?) ](https://docs.cloudfoundry.org/cf-cli/use-cli-plugins.html) on our [GitHub Releases page](https://github.com/cloudfoundry-incubator/netman-release/releases)
 
-`netman` provides a batteries included container to container system and several APIs for swapping in third party components.
-- IPAM and connectivity are provided by a swappable CNI plugin (`flannel` in the batteries included case).
-- A swappable policy agent polls garden and the policy server for polices to enforce on the cell. In the provided solution, the VXLAN policy agent writes iptables rules to filter packets based on VXLAN gbp tags.
-- Inbound traffic from the gorouter is port forwarded from the cell to the container via a NetIn rule. NetIn calls are made by garden to the external networker which then writes the iptables NAT rule.
-- Application security groups are enforced by NetOut calls from garden. The external networker also writes iptables rules to enforce ASGs.
-
-# Documentation
-
+## Documentation
 - [Architecture](docs/arch.md)
 - [Deploy to BOSH-lite](docs/bosh-lite.md)
 - [Deploy to AWS](docs/aws.md)
@@ -32,5 +29,5 @@ A [Garden-runC](https://github.com/cloudfoundry/garden-runc-release) add-on that
 - [Design doc for Container Networking Policy](https://docs.google.com/document/d/1HDS89TJKD7ACG6cqQHph5BdNSKLt8jvo6sPGBZ5DmsM)
 - [Engineering backlog](https://www.pivotaltracker.com/n/projects/1498342)
 - Chat with us at the `#container-networking` channel on [CloudFoundry Slack](http://slack.cloudfoundry.org/)
-- [CI dashboard](http://dashboard.c2c.cf-app.com) and [config](https://github.com/cloudfoundry-incubator/container-networking-ci)
+- [CI dashboard](http://dashboard.c2c.cf-app.com), [metrics](https://p.datadoghq.com/sb/f3af7f8e2-baf5212773?tv_mode=true) and [config](https://github.com/cloudfoundry-incubator/container-networking-ci)
 - [Documentation](./docs)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,18 @@
 # Netman
 
-Container Networking for CloudFoundry
+Netman provides policy-based container networking for Cloud Foundry.
+
+Netman integrates with [Garden-runC](https://github.com/cloudfoundry/garden-runc-release) in a
+[Diego](https://github.com/cloudfoundry/diego-release) deployment.  Additionally, a VM is deployed to act as a network Policy Server.
+A [JSON API](docs/API.md) and a [CF CLI plugin](docs/CLI.md) are available to control network policies.
+
+For more information about deploying Netman, look at our docs for [BOSH-lite](docs/bosh-lite.md) or [AWS](docs/aws.md).
 
 ## Downloads
-- BOSH release [ (?) ](http://bosh.io/docs/release.html) available on
+- [BOSH release](http://bosh.io/docs/release.html) available on
   [bosh.io](http://bosh.io/releases/github.com/cloudfoundry-incubator/netman-release)
   and [GitHub Releases](https://github.com/cloudfoundry-incubator/netman-release/releases)
-- CF CLI Plugin [ (?) ](https://docs.cloudfoundry.org/cf-cli/use-cli-plugins.html) on our [GitHub Releases page](https://github.com/cloudfoundry-incubator/netman-release/releases)
+- [CF CLI Plugin](https://docs.cloudfoundry.org/cf-cli/use-cli-plugins.html) on our [GitHub Releases page](https://github.com/cloudfoundry-incubator/netman-release/releases)
 
 ## Documentation
 - [Architecture](docs/arch.md)
@@ -28,6 +34,6 @@ Container Networking for CloudFoundry
 ## Project links
 - [Design doc for Container Networking Policy](https://docs.google.com/document/d/1HDS89TJKD7ACG6cqQHph5BdNSKLt8jvo6sPGBZ5DmsM)
 - [Engineering backlog](https://www.pivotaltracker.com/n/projects/1498342)
-- Chat with us at the `#container-networking` channel on [CloudFoundry Slack](http://slack.cloudfoundry.org/)
+- Chat with us at the `#container-networking` channel on [Cloud Foundry Slack](http://slack.cloudfoundry.org/)
 - [CI dashboard](http://dashboard.c2c.cf-app.com), [metrics](https://p.datadoghq.com/sb/f3af7f8e2-baf5212773?tv_mode=true) and [config](https://github.com/cloudfoundry-incubator/container-networking-ci)
 - [Documentation](./docs)

--- a/docs/arch.md
+++ b/docs/arch.md
@@ -1,6 +1,6 @@
 ## Overview
 
-Netman provides policy-driven container networking for CloudFoundry.
+Netman provides policy-driven container networking for Cloud Foundry.
 
 It has several components.  Some are "core" to the platform, others are "swappable" by operators.
 

--- a/docs/arch.md
+++ b/docs/arch.md
@@ -1,11 +1,27 @@
 ## Overview
 
+Netman provides policy-driven container networking for CloudFoundry.
+
+It has several components.  Some are "core" to the platform, others are "swappable" by operators.
+
 ![](https://github.com/cloudfoundry-incubator/container-networking-notes/blob/master/container_networking_block_digram.png?raw=true)
 
-`netman` provides a batteries included container to container system and several APIs for swapping in third party components.
-- IPAM and connectivity are provided by a swappable CNI plugin (`flannel` in the batteries included case).
-- A swappable policy agent polls garden and the policy server for polices to enforce on the cell. In the provided solution, the VXLAN policy agent writes iptables rules to filter packets based on VXLAN gbp tags.
-- Inbound traffic from the gorouter is port forwarded from the cell to the container via a NetIn rule. NetIn calls are made by garden to the external networker which then writes the iptables NAT rule.
-- Application security groups are enforced by NetOut calls from garden. The external networker also writes iptables rules to enforce ASGs.
 
+### Core components
+- [CF CLI plugin](usage.md) enables administrators to control network access policies between CF applications
+- Policy Server, a central management node, exposes a JSON REST API used by the CLI plugin
+- [Garden External Networker](../src/garden-external-networker), a [Garden-runC](https://github.com/cloudfoundry/garden-runc-release) add-on deployed to every Diego cell
+  - Invokes an operator-configured [CNI](https://github.com/containernetworking/cni) Plugin to set up the network for each app instance (container)
+  - Forwards ports to support incoming connections from the CF [HTTP Router](https://docs.cloudfoundry.org/concepts/http-routing.html),
+    [TCP Router](https://docs.cloudfoundry.org/adminguide/enabling-tcp-routing.html) and [Diego SSH Proxy](https://docs.cloudfoundry.org/concepts/diego/ssh-conceptual.html).
+  - Installs egress whitelist rules to support CF [Application Security Groups](https://docs.cloudfoundry.org/adminguide/app-sec-groups.html)
 
+### Batteries included, but swappable
+On every Diego cell
+- [Flannel](https://github.com/coreos/flannel) [CNI plugin](https://github.com/containernetworking/cni/tree/master/plugins/meta/flannel), provides IP address management and network connectivity to app instances (containers)
+  - Uses the flannel [VXLAN backend](https://github.com/coreos/flannel/tree/master/backend/vxlan)
+  - Every CF app instance gets a unique IP on a shared, flat L3 network
+- VXLAN Policy Agent enforces network policy for network traffic between applications
+  - Discovers desired network policies from the [Policy Server's Internal API](3rd-party.md#policy-server-internal-api)
+  - Updates IPTables rules on Diego cell to allow whitelisted ingress traffic
+  - Egress traffic is tagged with a unique identifier per source application, using the [VXLAN GBP header](https://tools.ietf.org/html/draft-smith-vxlan-group-policy-02#section-2.1)


### PR DESCRIPTION
- Remove duplication between README and arch doc
- Add download links to top of README
- Improve architecture doc page
  - Clarify which components are core vs swappable
  - Replace "netin" and "netout" references with user-facing language
  relating to routing and ASGs
  - Include links to relevant docs & OSS dependencies